### PR TITLE
Sanitize contact form inputs to prevent header injection

### DIFF
--- a/contact.php
+++ b/contact.php
@@ -14,6 +14,10 @@ $name    = trim(strip_tags($_POST["name"] ?? ""));
 $email   = filter_var(trim($_POST["email"] ?? ""), FILTER_SANITIZE_EMAIL);
 $message = trim(strip_tags($_POST["message"] ?? ""));
 
+// Nettoyage supplémentaire : empêche l'injection d'en-têtes via des retours à la ligne
+$name  = str_replace(["\r", "\n"], " ", $name);
+$email = str_replace(["\r", "\n"], "", $email);
+
 // 2) Validation
 if ($name === "" || $message === "" || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
   header("Location: index.html?status=error"); exit;


### PR DESCRIPTION
## Summary
- sanitize `name` and `email` fields in contact form to strip CRLF sequences, preventing header injection

## Testing
- `php -l contact.php`


------
https://chatgpt.com/codex/tasks/task_e_689b87d0c94c832c910b1bffc8c85774